### PR TITLE
Use embulk-util-timestamp instead of Embulk's org.embulk.spi.time.TimestampParser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk7
+jdk: oraclejdk8
 
 script: ./gradlew clean test
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,16 +18,17 @@ configurations {
 version = "0.2.0"
 
 compileJava.options.encoding = 'UTF-8' // source encoding
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.8.5"
-    provided "org.embulk:embulk-core:0.8.5"
+    compile  "org.embulk:embulk-core:0.9.17"
+    provided "org.embulk:embulk-core:0.9.17"
+    compile  "org.embulk:embulk-util-timestamp:0.1.1"
 
-    testCompile "junit:junit:4.+"
-    testCompile "org.embulk:embulk-standards:0.8.5"
-    testCompile "org.embulk:embulk-core:0.8.5:tests"
+    testCompile "junit:junit:4.12"
+    testCompile "org.embulk:embulk-standards:0.9.17"
+    testCompile "org.embulk:embulk-core:0.9.17:tests"
     testCompile "org.mockito:mockito-core:1.9.5"
 }
 

--- a/src/main/java/org/embulk/filter/add_time/AddTimeFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/add_time/AddTimeFilterPlugin.java
@@ -1,6 +1,6 @@
 package org.embulk.filter.add_time;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigException;
@@ -51,9 +51,40 @@ public class AddTimeFilterPlugin
         String getUnixTimestampUnit();
     }
 
-    public interface FromColumnConfig
-            extends Task, org.embulk.spi.time.TimestampParser.Task, org.embulk.spi.time.TimestampParser.TimestampColumnOption
+    public interface FromColumnConfig extends Task
     {
+        // Came from org.embulk.spi.time.TimestampParser.Task
+        @Config("default_timezone")
+        @ConfigDefault("\"UTC\"")
+        String getDefaultTimeZoneId();
+
+        // Came from org.embulk.spi.time.TimestampParser.Task
+        // But, this is overridden below.
+        // @Config("default_timestamp_format")
+        // @ConfigDefault("\"%Y-%m-%d %H:%M:%S.%N %z\"")
+        // String getDefaultTimestampFormat();
+
+        // Came from org.embulk.spi.time.TimestampParser.Task
+        @Config("default_date")
+        @ConfigDefault("\"1970-01-01\"")
+        String getDefaultDate();
+
+        // Came from org.embulk.spi.time.TimestampParser.TimestampColumnOption
+        @Config("timezone")
+        @ConfigDefault("null")
+        Optional<String> getTimeZoneId();
+
+        // Came from org.embulk.spi.time.TimestampParser.TimestampColumnOption
+        // But, this is overridden below.
+        // @Config("format")
+        // @ConfigDefault("null")
+        // Optional<String> getFormat();
+
+        // Came from org.embulk.spi.time.TimestampParser.TimestampColumnOption
+        @Config("date")
+        @ConfigDefault("null")
+        Optional<String> getDate();
+
         @Config("name")
         String getName();
 
@@ -74,9 +105,40 @@ public class AddTimeFilterPlugin
         Optional<String> getJsonKey();
     }
 
-    public interface FromValueConfig
-            extends Task, org.embulk.spi.time.TimestampParser.Task, org.embulk.spi.time.TimestampParser.TimestampColumnOption
+    public interface FromValueConfig extends Task
     {
+        // Came from org.embulk.spi.time.TimestampParser.Task
+        @Config("default_timezone")
+        @ConfigDefault("\"UTC\"")
+        String getDefaultTimeZoneId();
+
+        // Came from org.embulk.spi.time.TimestampParser.Task
+        // But, this is overridden below.
+        // @Config("default_timestamp_format")
+        // @ConfigDefault("\"%Y-%m-%d %H:%M:%S.%N %z\"")
+        // String getDefaultTimestampFormat();
+
+        // Came from org.embulk.spi.time.TimestampParser.Task
+        @Config("default_date")
+        @ConfigDefault("\"1970-01-01\"")
+        String getDefaultDate();
+
+        // Came from org.embulk.spi.time.TimestampParser.TimestampColumnOption
+        @Config("timezone")
+        @ConfigDefault("null")
+        Optional<String> getTimeZoneId();
+
+        // Came from org.embulk.spi.time.TimestampParser.TimestampColumnOption
+        // But, this is overridden below.
+        // @Config("format")
+        // @ConfigDefault("null")
+        // Optional<String> getFormat();
+
+        // Came from org.embulk.spi.time.TimestampParser.TimestampColumnOption
+        @Config("date")
+        @ConfigDefault("null")
+        Optional<String> getDate();
+
         @Config("mode")
         @ConfigDefault("\"fixed_time\"")
         String getMode();

--- a/src/main/java/org/embulk/filter/add_time/converter/SchemaConverter.java
+++ b/src/main/java/org/embulk/filter/add_time/converter/SchemaConverter.java
@@ -1,6 +1,6 @@
 package org.embulk.filter.add_time.converter;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.embulk.config.ConfigException;
 import org.embulk.filter.add_time.AddTimeFilterPlugin.PluginTask;
 import org.embulk.filter.add_time.AddTimeFilterPlugin.FromColumnConfig;

--- a/src/main/java/org/embulk/filter/add_time/converter/StringValueCastConverter.java
+++ b/src/main/java/org/embulk/filter/add_time/converter/StringValueCastConverter.java
@@ -1,33 +1,38 @@
 package org.embulk.filter.add_time.converter;
 
+import java.time.Instant;
 import org.embulk.filter.add_time.AddTimeFilterPlugin.FromColumnConfig;
 import org.embulk.filter.add_time.AddTimeFilterPlugin.ToColumnConfig;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
-import org.embulk.spi.time.TimestampParser;
+import org.embulk.util.timestamp.TimestampFormatter;
 
 public class StringValueCastConverter
         extends ValueCastConverter
 {
-    private final TimestampParser fromTimestampParser;
+    private final TimestampFormatter fromTimestampFormatter;
 
     public StringValueCastConverter(FromColumnConfig fromColumnConfig, ToColumnConfig toColumnConfig)
     {
         super(toColumnConfig);
-        this.fromTimestampParser = new TimestampParser(fromColumnConfig, fromColumnConfig);
+        final TimestampFormatter.Builder builder = TimestampFormatter.builder(
+                fromColumnConfig.getFormat().orElse(fromColumnConfig.getDefaultTimestampFormat()), true);
+        builder.setDefaultZoneFromString(fromColumnConfig.getTimeZoneId().orElse(fromColumnConfig.getDefaultTimeZoneId()));
+        builder.setDefaultDateFromString(fromColumnConfig.getDate().orElse(fromColumnConfig.getDefaultDate()));
+        this.fromTimestampFormatter = builder.build();
     }
 
     @Override
     public void convertValue(final Column column, String value, final PageBuilder pageBuilder)
     {
-        columnVisitor.setValue(stringToTimestamp(value));
+        columnVisitor.setValue(Timestamp.ofInstant(stringToInstant(value)));
         columnVisitor.setPageBuilder(pageBuilder);
         column.visit(columnVisitor);
     }
 
-    private Timestamp stringToTimestamp(String value)
+    private Instant stringToInstant(String value)
     {
-        return fromTimestampParser.parse(value);
+        return fromTimestampFormatter.parse(value);
     }
 }


### PR DESCRIPTION
`embulk-util-timestamp` has been released: https://github.com/embulk/embulk-util-timestamp/releases/tag/v0.1.1

Starting to use it in plugins, instead of `org.embulk.spi.time.TimestampParser`.