### PR TITLE
Bump up to v0.3.1-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "com.treasuredata.embulk.plugins"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.1-SNAPSHOT"
 description = "Add time column to the schema"
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
We're going to release v0.3.1 with #20 to support Embulk v0.9.23.